### PR TITLE
Allow the month field if the value of the field is zero

### DIFF
--- a/duration.go
+++ b/duration.go
@@ -15,8 +15,8 @@ var (
 	// ErrBadFormat is returned when parsing fails
 	ErrBadFormat = errors.New("bad format string")
 
-	// ErrNoMonth is raised when a month is in the format string
-	ErrNoMonth = errors.New("no months allowed")
+	// ErrNoMonth is raised when a month is in the format string unless it has a value of zero
+	ErrNoMonth = errors.New("non-zero value for months is not allowed")
 
 	tmpl = template.Must(template.New("duration").Parse(`P{{if .Years}}{{.Years}}Y{{end}}{{if .Weeks}}{{.Weeks}}W{{end}}{{if .Days}}{{.Days}}D{{end}}{{if .HasTimePart}}T{{end }}{{if .Hours}}{{.Hours}}H{{end}}{{if .Minutes}}{{.Minutes}}M{{end}}{{if .Seconds}}{{.Seconds}}S{{end}}`))
 
@@ -65,7 +65,10 @@ func FromString(dur string) (*Duration, error) {
 		case "year":
 			d.Years = val
 		case "month":
-			return nil, ErrNoMonth
+			// allow month if it's zero
+			if val != 0 {
+				return nil, ErrNoMonth
+			}
 		case "week":
 			d.Weeks = val
 		case "day":

--- a/duration_test.go
+++ b/duration_test.go
@@ -20,7 +20,7 @@ func TestFromString(t *testing.T) {
 	assert.Equal(t, err, duration.ErrNoMonth)
 
 	// test with good full string
-	dur, err := duration.FromString("P1Y2DT3H4M5S")
+	dur, err := duration.FromString("P1Y0M2DT3H4M5S")
 	assert.Nil(t, err)
 	assert.Equal(t, 1, dur.Years)
 	assert.Equal(t, 2, dur.Days)


### PR DESCRIPTION
Generally sane systems will not output a value for month due to the difficulties of parsing it, however it is possible to come
across systems that will include a value of zero for the month.

Given that a zero-valued month has no effect on the output here, this change allows that case, so that you can still use this
library to parse an otherwise valid duration.